### PR TITLE
blog/themes/3mdeb/static/css/bulma.css: add margin for post-cover images

### DIFF
--- a/blog/themes/3mdeb/static/css/bulma.css
+++ b/blog/themes/3mdeb/static/css/bulma.css
@@ -9687,6 +9687,12 @@ label.panel-block:hover {
   }
 }
 
+@media only screen and (min-width: 1280px) {
+  .post-cover {
+    margin-bottom: 5rem;
+  }
+}
+
 .footer {
   background-color: #fafafa;
   padding: 3rem 1.5rem 6rem;


### PR DESCRIPTION
This fixes post-cover images with categories layout

Signed-off-by: Artur Raglis <artur.raglis@3mdeb.com>