### PR TITLE
Fix workflow & update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,13 @@ jobs:
         run: cd ${GITHUB_WORKSPACE}/scripts && bash build.sh
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: static-content
           path: |
             scripts/deploy.sh
             blog/public/
+          include-hidden-files: true
 
   deploy:
     needs: [build]
@@ -57,7 +58,7 @@ jobs:
           sudo apt-get install -y sshpass
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: static-content
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           echo "HUGO_URL=${HUGO_URL}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/seo.yml
+++ b/.github/workflows/seo.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
 
       - name: Test links
         uses: 3mdeb/lychee-log-action@main
@@ -24,17 +24,17 @@ jobs:
     name: Check orphan pages
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           submodules: true
 
       - name: Checkout SEO Spy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           repository: 3mdeb/seo-spy
           path: seo-spy
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5.2.0
         with:
           python-version: '3.9'
 
@@ -44,7 +44,7 @@ jobs:
           pip install -r seo-spy/requirements.txt
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3.0.0
         with:
           extended: true
 
@@ -64,12 +64,12 @@ jobs:
     name: Check canonical links
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           submodules: true
 
       - name: Checkout SEO Spy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           repository: 3mdeb/seo-spy
           path: seo-spy
@@ -84,7 +84,7 @@ jobs:
           pip install -r seo-spy/requirements.txt
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3.0.0
         with:
           extended: true
 


### PR DESCRIPTION
Added `include-hidden-files: true` as default behaviour in versions before `v4.4.0` was to include them.
From what I can see we only include `blog/public/.htaccess`